### PR TITLE
Edit tsconfig.json to make VS Code find Assertions

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -17,6 +17,7 @@
     ],
     "useDefineForClassFields": false
   },
+  "exclude": ["./cypress.config.ts"],
   "angularCompilerOptions": {
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,


### PR DESCRIPTION
Our tests of our Angular components (unit tests/Karma tests) are using Jasmine assertions. 

There were lots of problems showing up as red, complaining, and highlighting in all kinds of ways even though the component tests worked just fine. This was a known problem, and a suggested workaround was to put an `exclude` in `tsconfig.json` that makes it so that Chai assertions that are supplied by Cypress won't accidentally make it so that Jasmine assertions are hidden. We do this by excluding those things in the `cypress.config.ts` when we are looking at our Karma tests.